### PR TITLE
correct maven group id in readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -75,7 +75,7 @@ testImplementation ('org.springframework.experimental.boot:spring-boot-testjars'
 [source,xml]
 ----
 <dependency>
-    <groupId>org.springframework.boot.experimental</groupId>
+    <groupId>org.springframework.experimental.boot</groupId>
     <artifactId>spring-boot-testjars</artifactId>
     <classifier>maven</classifier>
 </dependency>


### PR DESCRIPTION
change maven group id.

SNAPSHOTS exists at below location - https://repo.spring.io/ui/native/libs-snapshot/org/springframework/experimental/boot/spring-boot-testjars/0.0.1-SNAPSHOT/