### PR TITLE
Fixed some errors in README.md

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -33,7 +33,7 @@ testImplementation ('org.springframework.experimental.boot:spring-boot-testjars:
 <dependency>
     <groupId>org.springframework.experimental.boot</groupId>
     <artifactId>spring-boot-testjars</artifactId>
-    <scope>{TESTJARS_VERSION}</scope>
+    <version>{TESTJARS_VERSION}</version>
 </dependency>
 ----
 
@@ -102,7 +102,7 @@ testImplementation ('org.springframework.experimental.boot:spring-boot-testjars:
     <groupId>org.springframework.experimental.boot</groupId>
     <artifactId>spring-boot-testjars</artifactId>
     <classifier>maven</classifier>
-    <scope>{TESTJARS_VERSION}</scope>
+    <version>{TESTJARS_VERSION}</version>
 </dependency>
 ----
 


### PR DESCRIPTION
I just wanted to quickly fix two errors in the the README.md!

Maven samples where using `<scope>` instead of `<version>`!

Hopefully everything is fixed correctly!

Thanks for the awesome library/extension ... already gave it a try and will include it in my lectures tomorrow!

cheers
Klaus