### PR TITLE
Add Cloud Config sample

### DIFF
--- a/samples/cloud-config/build.gradle
+++ b/samples/cloud-config/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.4.0'
+    id 'io.spring.dependency-management' version '1.1.2'
+}
+
+group = 'com.example'
+
+java {
+    sourceCompatibility = '17'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation project(':spring-boot-testjars')
+    testImplementation project(':spring-boot-testjars-maven')
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/samples/cloud-config/src/main/java/example/cloud/config/CloudConfigMain.java
+++ b/samples/cloud-config/src/main/java/example/cloud/config/CloudConfigMain.java
@@ -1,0 +1,11 @@
+package example.cloud.config;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CloudConfigMain {
+    public static void main(String[] args) {
+        SpringApplication.run(CloudConfigMain.class, args);
+    }
+}

--- a/samples/cloud-config/src/main/resources/config-native/application.yml
+++ b/samples/cloud-config/src/main/resources/config-native/application.yml
@@ -1,0 +1,2 @@
+some:
+  value: Hello!

--- a/samples/cloud-config/src/test/java/example/cloud/config/CloudConfigMainTest.java
+++ b/samples/cloud-config/src/test/java/example/cloud/config/CloudConfigMainTest.java
@@ -1,0 +1,26 @@
+package example.cloud.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(classes = TestCloudConfigMain.class)
+public class CloudConfigMainTest {
+    @Test
+    void configServerPropertyTest(@Value("${spring.cloud.config.uri}") String configUri) {
+        String url = configUri + "/application/default";
+        RestClient restClient = RestClient.create();
+        ResponseEntity<String> result = restClient.get()
+                .uri(url)
+                .retrieve()
+                .toEntity(String.class);
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertTrue(result.getBody().contains("Hello!"));
+    }
+}

--- a/samples/cloud-config/src/test/java/example/cloud/config/TestCloudConfigMain.java
+++ b/samples/cloud-config/src/test/java/example/cloud/config/TestCloudConfigMain.java
@@ -1,0 +1,36 @@
+package example.cloud.config;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.experimental.boot.server.exec.CommonsExecWebServerFactoryBean;
+import org.springframework.experimental.boot.server.exec.MavenClasspathEntry;
+import org.springframework.experimental.boot.server.exec.ResourceClasspathEntry;
+import org.springframework.experimental.boot.test.context.CloudConfigUri;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestCloudConfigMain {
+    @Bean
+    @CloudConfigUri
+    static CommonsExecWebServerFactoryBean configServer() {
+        // @formatter:off
+        return CommonsExecWebServerFactoryBean.builder()
+                .useGenericSpringBootMain()
+                .setAdditionalBeanClassNames("org.springframework.cloud.config.server.config.ConfigServerConfiguration")
+                .systemProperties(props -> {
+                    props.put("spring.config.location", "classpath:/application.yml");
+                })
+                .classpath((classpath) -> classpath
+                        .entries(new MavenClasspathEntry("org.springframework.cloud:spring-cloud-config-server:4.2.1"))
+                        .entries(new ResourceClasspathEntry("config-native/application.yml", "config-native/application.yml"))
+                        .entries(new ResourceClasspathEntry("testjars/configServer/application.yml", "application.yml"))
+                );
+        // @formatter:on
+    }
+
+    public static void main(String[] args) throws Exception {
+        SpringApplication.from(CloudConfigMain::main)
+                .with(TestCloudConfigMain.class)
+                .run(args);
+    }
+}

--- a/samples/cloud-config/src/test/resources/testjars/configServer/application.yml
+++ b/samples/cloud-config/src/test/resources/testjars/configServer/application.yml
@@ -1,0 +1,8 @@
+spring:
+  profiles:
+    active: native
+  cloud:
+    config:
+      server:
+        native:
+          search-locations: classpath:/config-native

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,3 +14,5 @@ include ':spring-boot-testjars'
 include ':spring-boot-testjars-maven'
 include ':samples:oauth2-login'
 include ':samples:oauth2-login-custom-config'
+include 'samples:cloud-config'
+


### PR DESCRIPTION
This is where I added `cloud-config-sample`. Of interest, I used `props.put(“spring.config.location”, “classpath:/application.yml”)` to load application.yml for the spring context. If this can be done in a better way, I'd love to hear advice. To start the cloud config server, I was loading the `ConfigServerConfiguration` bean.

I also made the response check with .contains(“Hello!”), in order not to apply additional logic to extract the value from the json. Do you think such a check which is now enough?

Fix: #77 