### PR TITLE
Add FileClasspathEntry validation

### DIFF
--- a/spring-boot-testjars/src/main/java/org/springframework/experimental/boot/server/exec/FileClasspathEntry.java
+++ b/spring-boot-testjars/src/main/java/org/springframework/experimental/boot/server/exec/FileClasspathEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,13 @@ public class FileClasspathEntry implements ClasspathEntry {
 
 	private final File file;
 
-	public FileClasspathEntry(String file) {
-		this(new File(file));
+	public FileClasspathEntry(String filePath) {
+		File file = new File(filePath);
+		if (!file.isDirectory() && !file.getName().toLowerCase().endsWith("jar")) {
+			String absolutePath = file.getAbsolutePath();
+			throw new IllegalArgumentException("File must be a jar file or directory '" + absolutePath + "'");
+		}
+		this.file = file;
 	}
 
 	public FileClasspathEntry(File file) {

--- a/spring-boot-testjars/src/test/java/org/springframework/experimental/boot/server/exec/FileClasspathEntryTests.java
+++ b/spring-boot-testjars/src/test/java/org/springframework/experimental/boot/server/exec/FileClasspathEntryTests.java
@@ -20,6 +20,7 @@ import java.io.File;
 
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 class FileClasspathEntryTests {
@@ -30,6 +31,13 @@ class FileClasspathEntryTests {
 		FileClasspathEntry notFoundEntry = new FileClasspathEntry(doesNotExist);
 		assertThatIllegalStateException().isThrownBy(notFoundEntry::resolve)
 				.withMessageContaining("Could not find file to add to the classpath");
+	}
+
+	@Test
+	void constructorWhenNotJarOrDirectoryThrowsIllegalArgumentException() {
+		String invalidPath = "some-file.txt";
+		assertThatIllegalArgumentException().isThrownBy(() -> new FileClasspathEntry(invalidPath))
+				.withMessageContaining("File must be a jar file or directory");
 	}
 
 }


### PR DESCRIPTION
Since it doesn't make sense to throw a non-directory or jar file into `FileClasspathEntry`, I think it's worth adding a check to the constructor.

Fix: #59 