### PR TITLE
Bump maven version to 3.9.6 to match mavenResolverVersion 1.9.18

### DIFF
--- a/spring-boot-testjars-maven/build.gradle
+++ b/spring-boot-testjars-maven/build.gradle
@@ -10,7 +10,7 @@ group = 'org.springframework.experimental.boot'
 
 ext {
 	mavenResolverVersion = '1.9.18'
-	mavenVersion = '3.9.4'
+	mavenVersion = '3.9.6'
 }
 
 java {


### PR DESCRIPTION
Resolve resolution conflict exceptions where 3.9.4 of maven depends on 1.9.14 of mavenResolverVersion. Sync'ing the mavenVersion to 3.9.6 with the declared mavenResolveVersion 1.9.18 eliminates the version conflict. 

see: https://github.com/apache/maven/blob/maven-3.9.6/pom.xml