### PR TITLE
Include plexus-utils as runtimeOnly dependency

### DIFF
--- a/spring-boot-testjars-maven/build.gradle
+++ b/spring-boot-testjars-maven/build.gradle
@@ -11,6 +11,7 @@ group = 'org.springframework.experimental.boot'
 ext {
 	mavenResolverVersion = '1.9.18'
 	mavenVersion = '3.9.4'
+	plexusUtilsVersion = '3.5.1'
 }
 
 java {
@@ -39,6 +40,7 @@ dependencies {
 	api "org.apache.maven.resolver:maven-resolver-transport-file:${mavenResolverVersion}"
 	api "org.apache.maven.resolver:maven-resolver-transport-http:${mavenResolverVersion}"
 	api "org.apache.maven.resolver:maven-resolver-supplier:${mavenResolverVersion}"
+	runtimeOnly "org.codehaus.plexus:plexus-utils:${plexusUtilsVersion}"
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework:spring-web'
 }


### PR DESCRIPTION
If plexus-utils is not included a null pointer exception is thrown by `CommonsExecWebServerFactoryBean`.

```
java.lang.NullPointerException: Cannot invoke "org.eclipse.aether.RepositorySystem.newLocalRepositoryManager(org.eclipse.aether.RepositorySystemSession, org.eclipse.aether.repository.LocalRepository)" because "system" is null
	at app//org.springframework.experimental.boot.server.exec.MavenClasspathEntry.newRepositorySystemSession(MavenClasspathEntry.java:239)
	at app//org.springframework.experimental.boot.server.exec.MavenClasspathEntry.resolve(MavenClasspathEntry.java:164)
	at app//org.springframework.experimental.boot.server.exec.ClasspathBuilder.lambda$build$0(ClasspathBuilder.java:55)
	at java.base@21.0.7/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:273)
	at java.base@21.0.7/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.base@21.0.7/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base@21.0.7/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base@21.0.7/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base@21.0.7/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base@21.0.7/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at app//org.springframework.experimental.boot.server.exec.ClasspathBuilder.build(ClasspathBuilder.java:56)
	at app//org.springframework.experimental.boot.server.exec.CommonsExecWebServerFactoryBean.build(CommonsExecWebServerFactoryBean.java:160)
	at app//org.springframework.experimental.boot.server.exec.CommonsExecWebServerFactoryBean.getObject(CommonsExecWebServerFactoryBean.java:183)
	at app//org.springframework.experimental.boot.server.exec.CommonsExecWebServerFactoryBean.getObject(CommonsExecWebServerFactoryBean.java:47)
```